### PR TITLE
Allow preprocessor to emit ImportStatements, fixing contrib libs.

### DIFF
--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -413,6 +413,10 @@ public class PreprocessingService {
       throw new RuntimeException("Unexpected sketch exception in preprocessing: " + e);
     }
 
+    // Save off the imports
+    programImports.addAll(preprocessorResult.getImportStatements());
+    result.programImports.addAll(preprocessorResult.getImportStatements());
+
     // Prepare transforms to convert pde code into parsable code
     TextTransform toParsable = new TextTransform(pdeStage);
     toParsable.addAll(preprocessorResult.getEdits());

--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -4,6 +4,8 @@ package processing.mode.java.preproc;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -12,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import processing.app.Preferences;
 import processing.app.SketchException;
+import processing.mode.java.pdex.ImportStatement;
 import processing.mode.java.preproc.issue.PdeIssueEmitter;
 import processing.mode.java.preproc.issue.PdePreprocessIssueException;
 

--- a/java/src/processing/mode/java/preproc/PreprocessorResult.java
+++ b/java/src/processing/mode/java/preproc/PreprocessorResult.java
@@ -1,10 +1,13 @@
 package processing.mode.java.preproc;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import processing.app.SketchException;
+import processing.mode.java.pdex.ImportStatement;
 import processing.mode.java.pdex.TextTransform;
 import processing.mode.java.preproc.PdePreprocessor;
 
@@ -17,6 +20,7 @@ public class PreprocessorResult {
   private final int headerOffset;
   private final String className;
   private final List<String> extraImports;
+  private final List<ImportStatement> importStatements;
   private final PdePreprocessor.Mode programType;
   private final List<TextTransform.Edit> edits;
 
@@ -42,6 +46,10 @@ public class PreprocessorResult {
     extraImports = Collections.unmodifiableList(new ArrayList<>(newExtraImports));
     programType = newProgramType;
     edits = newEdits;
+
+    importStatements = extraImports.stream()
+        .map(ImportStatement::parse)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -90,4 +98,12 @@ public class PreprocessorResult {
     return edits;
   }
 
+  /**
+   * Get the found import statements as {ImportStatement}s.
+   *
+   * @return The import statements found for the user.
+   */
+  public List<ImportStatement> getImportStatements() {
+    return importStatements;
+  }
 }


### PR DESCRIPTION
Allow the preprocessor to emit ImportStatements, allowing the JDT to read extra libraries (including contributed ones) at compilation time.