### PR TITLE
Fixes ANTLR visibility method modifiers and static class handling

### DIFF
--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -407,7 +407,7 @@ editor.status.hiding_enclosing_type = The class "%s" cannot have the same name a
 
 editor.status.bad.assignment = Possible error on variable assignment near '%s'?
 editor.status.bad.generic = Possibly missing type in generic near '%s'?
-editor.status.bad.identifier = Bad identifier? Did you start an identifier with digits near '%s'?
+editor.status.bad.identifier = Bad identifier? Did you forget a variable or start an identifier with digits near '%s'?
 editor.status.bad.parameter = Error on parameter or method declaration near '%s'?
 editor.status.extraneous = Unexpected extra code near '%s'?
 editor.status.mismatched = Missing operator or semicolon near '%s'?

--- a/build/shared/lib/languages/PDE_es.properties
+++ b/build/shared/lib/languages/PDE_es.properties
@@ -384,7 +384,7 @@ editor.status.hiding_enclosing_type = Las clase "%s" no puede tener el mismo nom
 
 # Extended syntax error translation
 editor.status.bad.assignment = Error en este asignación de variable cerca '%s'?
-editor.status.bad.identifier = Error en este identificador? Es posible que tu empezaste un identificador con un numero cerca '%s'?
+editor.status.bad.identifier = Error en este identificador? Es posible que tu olvidaste un variable o empezaste un identificador con un numero cerca '%s'?
 editor.status.bad.generic = Error en genérico cerca '%s'. Falta un tipo?
 editor.status.bad.parameter = Error en un parámetro o una declaración de método cerca '%s'?
 editor.status.extraneous = Imprevisto clave cerca '%s'?

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -324,9 +324,12 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
       if (isSizeValidInGlobal) {
         // TODO: uncomment if size is supposed to be removed from setup()
+
+        createDelete(ctx.start, ctx.stop);
+
         createInsertBefore(
             ctx.start,
-            "/* commented out by preprocessor: "
+            "/* size commented out by preprocessor"
         );
 
         createInsertAfter(ctx.stop, " */");

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -234,7 +234,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
   }*/
 
   /**
-   * Endpoint for ANTLR to call when finished parsing a size function call.
+   * Endpoint for ANTLR to call when finished parsing a method invocatino.
    *
    * @param ctx The ANTLR context for the method call.
    */
@@ -244,12 +244,24 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
     }
   }
 
-  public void exitMethodInvocation_lfno_primary(ProcessingParser.MethodInvocation_lf_primaryContext ctx) {
+  /**
+   * Endpoing for ANTLR when finishing a left recursive method invocation.
+   *
+   * @param ctx The ANTLR context for the method call.
+   */
+  public void exitMethodInvocation_lfno_primary(
+      ProcessingParser.MethodInvocation_lf_primaryContext ctx) {
+
     if (SIZE_METHOD_NAME.equals(ctx.getChild(0).getText())) {
       handleSizeCall(ctx);
     }
   }
 
+  /**
+   * Manage parsing out a size call.
+   *
+   * @param ctx The context of the call.
+   */
   private void handleSizeCall(ParserRuleContext ctx) {
     // this tree climbing could be avoided if grammar is
     // adjusted to force context of size()
@@ -323,6 +335,12 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
     }
   }
 
+  /**
+   * Determine if a method declaration is for setup.
+   *
+   * @param methodDeclaration The method declaration to parse.
+   * @return True if setup and false otherwise.
+   */
   private boolean isMethodSetup(ParserRuleContext methodDeclaration) {
     ParseTree methodHeader = null;
 
@@ -465,9 +483,10 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
     boolean voidType = ctx.getChild(0).getChild(0).getText().equals("void");
 
     // not the first, so no mod before
-    boolean hasModifier = clsBdyDclCtx.getChild(0) != memCtx;
+    ParseTree modifierMaybe = ctx.getChild(0);
+    boolean hasModifier = modifierMaybe instanceof ProcessingParser.MethodModifierContext;
 
-    if (!hasModifier && inPAppletContext && voidType) {
+    if (!hasModifier) {
       createInsertBefore(memCtx.start, "public ");
     }
 

--- a/java/src/processing/mode/java/preproc/Processing.g4
+++ b/java/src/processing/mode/java/preproc/Processing.g4
@@ -33,6 +33,7 @@ javaProcessingSketch
 nonClassBlockStatement
 	:	localVariableDeclarationStatement
 	|	statement
+	|   typeDeclaration
 	;
 
 staticProcessingSketch

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -340,4 +340,9 @@ public class ParserTests {
     expectGood("specialmethodsprivate", true);
   }
 
+  @Test
+  public void classInStatic() {
+    expectGood("classinstatic", true);
+  }
+
 }

--- a/java/test/resources/annotations.expected
+++ b/java/test/resources/annotations.expected
@@ -19,7 +19,7 @@ public class annotations extends PApplet {
 
 
 public void setup() {
-    /* commented out by preprocessor: size(200,200) */;
+    /* size commented out by preprocessor */;
 }
 
 @Deprecated

--- a/java/test/resources/bug136.expected
+++ b/java/test/resources/bug136.expected
@@ -20,7 +20,7 @@ public class bug136 extends PApplet {
 java.util.List alist = Collections.synchronizedList(new ArrayList());
 
 public void setup() {
-/* commented out by preprocessor: size(400, 200) */;
+/* size commented out by preprocessor */;
 alist.add("hello");
 }
 

--- a/java/test/resources/bug315g.expected
+++ b/java/test/resources/bug315g.expected
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class bug315g extends PApplet {
 
     public void setup() {
-/* commented out by preprocessor: size(480, 120) */;
+/* size commented out by preprocessor */;
 smooth();
 int y;
 y = 60;

--- a/java/test/resources/bug4.expected
+++ b/java/test/resources/bug4.expected
@@ -17,7 +17,7 @@ public class bug4 extends PApplet {
     public void setup() {
 int x = 12;
 float u = (PApplet.parseFloat(x)/width);
-/* commented out by preprocessor: size(100,100) */;
+/* size commented out by preprocessor */;
 
         noLoop();
     }

--- a/java/test/resources/bug4.pde
+++ b/java/test/resources/bug4.pde
@@ -1,3 +1,3 @@
 int x = 12;
 float u = (float(x)/width);
-size(100,100);
+size(100, /** test **/ 100);

--- a/java/test/resources/classinstatic.expected
+++ b/java/test/resources/classinstatic.expected
@@ -12,14 +12,26 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
-public class bug1442 extends PApplet {
+public class classinstatic extends PApplet {
 
-public float a() {
-	return 1.0f;
+    public void setup() {
+class Test {
+
+  public int getInt() { return 5; }
+  public String toString() {return "test";}
+
 }
 
+
+Test t = new Test();
+println(t.getInt());
+println(t.toString());
+
+        noLoop();
+    }
+
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1442" };
+        String[] appletArgs = new String[] { "classinstatic" };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/classinstatic.pde
+++ b/java/test/resources/classinstatic.pde
@@ -1,0 +1,11 @@
+class Test {
+
+  int getInt() { return 5; }
+  String toString() {return "test";}
+
+}
+
+
+Test t = new Test();
+println(t.getInt());
+println(t.toString());

--- a/java/test/resources/specialmethodsprivate.expected
+++ b/java/test/resources/specialmethodsprivate.expected
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class specialmethodsprivate extends PApplet {
 
 public void setup() {
-    /* commented out by preprocessor: size(100, 100) */;
+    /* size commented out by preprocessor */;
 }
 
 public void draw() {

--- a/java/test/resources/speicalmethods.expected
+++ b/java/test/resources/speicalmethods.expected
@@ -17,7 +17,7 @@ public class speicalmethods extends PApplet {
 ArrayList<Integer> positions = new ArrayList<>();
 
 public void setup() {
-    /* commented out by preprocessor: size(100, 100) */;
+    /* size commented out by preprocessor */;
     positions.add(25);
     positions.add(50);
     positions.add(75);


### PR DESCRIPTION
Fixes ANTLR static mode determination as well as  changes visibility method modifiers. Specifically, for consistency with prior processing, disallow use of the default visibility and instead prepend public modifier if no modifier is given.