### PR TITLE
[antlr branch] Fix issues related to sampottinger#37.

### DIFF
--- a/java/src/processing/mode/java/pdex/JdtCompilerUtil.java
+++ b/java/src/processing/mode/java/pdex/JdtCompilerUtil.java
@@ -1,0 +1,106 @@
+package processing.mode.java.pdex;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Utility to help run a compilation through the JDT.
+ */
+public class JdtCompilerUtil {
+
+  /**
+   * Create a JDT compilation unit.
+   *
+   * @param parser The parser to use to read the source.
+   * @param source The source after processing with ANTLR.
+   * @param options The JDT compiler options.
+   * @return The JDT parsed compilation unit.
+   */
+  public static CompilationUnit makeAST(ASTParser parser,
+                                         char[] source,
+                                         Map<String, String> options) {
+    parser.setSource(source);
+    parser.setKind(ASTParser.K_COMPILATION_UNIT);
+    parser.setCompilerOptions(options);
+    parser.setStatementsRecovery(true);
+
+    return (CompilationUnit) parser.createAST(null);
+  }
+
+  /**
+   * Establish parser options before creating a JDT compilation unit.
+   *
+   * @param parser The parser to use to read the source.
+   * @param source The source after processing with ANTLR.
+   * @param options The JDT compiler options.
+   * @param className The name of the sketch.
+   * @param classPath The classpath to use in compliation.
+   * @return The JDT parsed compilation unit.
+   */
+  public static CompilationUnit makeASTWithBindings(ASTParser parser,
+                                                     char[] source,
+                                                     Map<String, String> options,
+                                                     String className,
+                                                     String[] classPath) {
+    parser.setSource(source);
+    parser.setKind(ASTParser.K_COMPILATION_UNIT);
+    parser.setCompilerOptions(options);
+    parser.setStatementsRecovery(true);
+    parser.setUnitName(className);
+    parser.setEnvironment(classPath, null, null, false);
+    parser.setResolveBindings(true);
+
+    return (CompilationUnit) parser.createAST(null);
+  }
+
+
+  static public final Map<String, String> COMPILER_OPTIONS;
+  static {
+    Map<String, String> compilerOptions = new HashMap<>();
+
+    compilerOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_11);
+    compilerOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_11);
+    compilerOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_11);
+
+    // See http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Fguide%2Fjdt_api_options.htm&anchor=compiler
+
+    final String[] generate = {
+        JavaCore.COMPILER_LINE_NUMBER_ATTR,
+        JavaCore.COMPILER_SOURCE_FILE_ATTR
+    };
+
+    final String[] ignore = {
+        JavaCore.COMPILER_PB_UNUSED_IMPORT,
+        JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION,
+        JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE,
+        JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS,
+        JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION
+    };
+
+    final String[] warn = {
+        JavaCore.COMPILER_PB_NO_EFFECT_ASSIGNMENT,
+        JavaCore.COMPILER_PB_NULL_REFERENCE,
+        JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE,
+        JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK,
+        JavaCore.COMPILER_PB_POSSIBLE_ACCIDENTAL_BOOLEAN_ASSIGNMENT,
+        JavaCore.COMPILER_PB_UNUSED_LABEL,
+        JavaCore.COMPILER_PB_UNUSED_LOCAL,
+        JavaCore.COMPILER_PB_UNUSED_OBJECT_ALLOCATION,
+        JavaCore.COMPILER_PB_UNUSED_PARAMETER,
+        JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER
+    };
+
+    for (String s : generate) compilerOptions.put(s, JavaCore.GENERATE);
+    for (String s : ignore)   compilerOptions.put(s, JavaCore.IGNORE);
+    for (String s : warn)     compilerOptions.put(s, JavaCore.WARNING);
+
+    COMPILER_OPTIONS = Collections.unmodifiableMap(compilerOptions);
+  }
+
+}

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -37,7 +37,6 @@ import java.util.stream.StreamSupport;
 
 import javax.swing.text.BadLocationException;
 
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
@@ -51,7 +50,6 @@ import processing.mode.java.JavaMode;
 import processing.mode.java.pdex.TextTransform.OffsetMapper;
 import processing.mode.java.pdex.util.ProblemFactory;
 import processing.mode.java.pdex.util.runtime.RuntimePathBuilder;
-import processing.mode.java.preproc.issue.PdePreprocessIssueException;
 import processing.mode.java.preproc.PdePreprocessor;
 import processing.mode.java.preproc.PreprocessorResult;
 import processing.mode.java.preproc.code.SyntaxUtil;
@@ -463,9 +461,11 @@ public class PreprocessingService {
 
     // Create intermediate AST for advanced preprocessing
     //System.out.addEmptyLine(new String(parsableStage.toCharArray()));
-    //System.out.println(new String(parsableStage.toCharArray()));
-    CompilationUnit parsableCU =
-        makeAST(parser, parsableStage.toCharArray(), COMPILER_OPTIONS);
+    CompilationUnit parsableCU = JdtCompilerUtil.makeAST(
+        parser,
+        parsableStage.toCharArray(),
+        JdtCompilerUtil.COMPILER_OPTIONS
+    );
 
     // Prepare advanced transforms which operate on AST
     TextTransform toCompilable = new TextTransform(parsableStage);
@@ -478,7 +478,7 @@ public class PreprocessingService {
 
     // Create compilable AST to get syntax problems
     CompilationUnit compilableCU =
-        makeAST(parser, compilableStageChars, COMPILER_OPTIONS);
+        JdtCompilerUtil.makeAST(parser, compilableStageChars, JdtCompilerUtil.COMPILER_OPTIONS);
 
     // Get syntax problems from compilable AST
     result.hasSyntaxErrors |= Arrays.stream(compilableCU.getProblems())
@@ -486,9 +486,13 @@ public class PreprocessingService {
 
     // Generate bindings after getting problems - avoids
     // 'missing type' errors when there are syntax problems
-    CompilationUnit bindingsCU =
-        makeASTWithBindings(parser, compilableStageChars, COMPILER_OPTIONS,
-                            className, result.classPathArray);
+    CompilationUnit bindingsCU = JdtCompilerUtil.makeASTWithBindings(
+          parser,
+          compilableStageChars,
+          JdtCompilerUtil.COMPILER_OPTIONS,
+          className,
+          result.classPathArray
+    );
 
     // Get compilation problems
     List<IProblem> bindingsProblems = Arrays.asList(bindingsCU.getProblems());
@@ -577,95 +581,6 @@ public class PreprocessingService {
 
   /// --------------------------------------------------------------------------
 
-
-  /**
-   * Create a JDT compilation unit.
-   *
-   * @param parser The parser to use to read the source.
-   * @param source The source after processing with ANTLR.
-   * @param options The JDT compiler options.
-   * @return The JDT parsed compilation unit.
-   */
-  private static CompilationUnit makeAST(ASTParser parser,
-                                           char[] source,
-                                           Map<String, String> options) {
-    parser.setSource(source);
-    parser.setKind(ASTParser.K_COMPILATION_UNIT);
-    parser.setCompilerOptions(options);
-    parser.setStatementsRecovery(true);
-
-    return (CompilationUnit) parser.createAST(null);
-  }
-
-  /**
-   * Establish parser options before creating a JDT compilation unit.
-   *
-   * @param parser The parser to use to read the source.
-   * @param source The source after processing with ANTLR.
-   * @param options The JDT compiler options.
-   * @param className The name of the sketch.
-   * @param classPath The classpath to use in compliation.
-   * @return The JDT parsed compilation unit.
-   */
-  private static CompilationUnit makeASTWithBindings(ASTParser parser,
-                                                       char[] source,
-                                                       Map<String, String> options,
-                                                       String className,
-                                                       String[] classPath) {
-    parser.setSource(source);
-    parser.setKind(ASTParser.K_COMPILATION_UNIT);
-    parser.setCompilerOptions(options);
-    parser.setStatementsRecovery(true);
-    parser.setUnitName(className);
-    parser.setEnvironment(classPath, null, null, false);
-    parser.setResolveBindings(true);
-
-    return (CompilationUnit) parser.createAST(null);
-  }
-
-
-  static private final Map<String, String> COMPILER_OPTIONS;
-  static {
-    Map<String, String> compilerOptions = new HashMap<>();
-
-    compilerOptions.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_11);
-    compilerOptions.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_11);
-    compilerOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_11);
-
-    // See http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Fguide%2Fjdt_api_options.htm&anchor=compiler
-
-    final String[] generate = {
-        JavaCore.COMPILER_LINE_NUMBER_ATTR,
-        JavaCore.COMPILER_SOURCE_FILE_ATTR
-    };
-
-    final String[] ignore = {
-        JavaCore.COMPILER_PB_UNUSED_IMPORT,
-        JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION,
-        JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE,
-        JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS,
-        JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION
-    };
-
-    final String[] warn = {
-        JavaCore.COMPILER_PB_NO_EFFECT_ASSIGNMENT,
-        JavaCore.COMPILER_PB_NULL_REFERENCE,
-        JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE,
-        JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK,
-        JavaCore.COMPILER_PB_POSSIBLE_ACCIDENTAL_BOOLEAN_ASSIGNMENT,
-        JavaCore.COMPILER_PB_UNUSED_LABEL,
-        JavaCore.COMPILER_PB_UNUSED_LOCAL,
-        JavaCore.COMPILER_PB_UNUSED_OBJECT_ALLOCATION,
-        JavaCore.COMPILER_PB_UNUSED_PARAMETER,
-        JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER
-    };
-
-    for (String s : generate) compilerOptions.put(s, JavaCore.GENERATE);
-    for (String s : ignore)   compilerOptions.put(s, JavaCore.IGNORE);
-    for (String s : warn)     compilerOptions.put(s, JavaCore.WARNING);
-
-    COMPILER_OPTIONS = Collections.unmodifiableMap(compilerOptions);
-  }
 
   /**
    * Emit events and update internal state (isEnabled) if java tabs added or modified.

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -477,6 +477,8 @@ public class PreprocessingService {
     char[] compilableStageChars = compilableStage.toCharArray();
 
     // Create compilable AST to get syntax problems
+    //System.out.println(new String(compilableStageChars));
+    //System.out.println("-----");
     CompilationUnit compilableCU =
         JdtCompilerUtil.makeAST(parser, compilableStageChars, JdtCompilerUtil.COMPILER_OPTIONS);
 

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -197,8 +197,8 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
     allImports.addAll(foundImports);
 
     List<TextTransform.Edit> allEdits = new ArrayList<>();
-    allEdits.addAll(edits);
     allEdits.addAll(headerResult.getEdits());
+    allEdits.addAll(edits);
     allEdits.addAll(footerResult.getEdits());
 
     return new PreprocessorResult(mode, lineOffset, sketchName, allImports, allEdits);

--- a/java/src/processing/mode/java/preproc/code/CodeEditOperationUtil.java
+++ b/java/src/processing/mode/java/preproc/code/CodeEditOperationUtil.java
@@ -109,18 +109,19 @@ public class CodeEditOperationUtil {
   /**
    * Insert text before a position in code.
    *
-   * @param before The location before which to insert the text.
+   * @param before The location before which to insert the text in tokens.
+   * @param beforeOffset THe location before which to insert the text in chars.
    * @param text The text to insert.
    * @param rewriter The rewriter in which to immediately edit.
    * @return The {TextTransform.Edit} corresponding to this change.
    */
-  public static TextTransform.Edit createInsertBefore(int before, String text,
+  public static TextTransform.Edit createInsertBefore(int before, int beforeOffset, String text,
         TokenStreamRewriter rewriter) {
 
     rewriter.insertBefore(before, text);
 
     return TextTransform.Edit.insert(
-        before,
+        beforeOffset,
         text
     );
   }

--- a/java/src/processing/mode/java/preproc/code/PrintWriterWithEditGen.java
+++ b/java/src/processing/mode/java/preproc/code/PrintWriterWithEditGen.java
@@ -73,6 +73,7 @@ public class PrintWriterWithEditGen {
     if (before) {
       rewriteResultBuilder.addEdit(CodeEditOperationUtil.createInsertBefore(
           insertPoint,
+          insertPoint,
           newCode,
           writer
       ));

--- a/java/test/processing/mode/java/preproc/code/CodeEditOperationUtilTest.java
+++ b/java/test/processing/mode/java/preproc/code/CodeEditOperationUtilTest.java
@@ -91,6 +91,7 @@ public class CodeEditOperationUtilTest {
   public void createInsertBeforeLocation() {
     TextTransform.Edit edit = CodeEditOperationUtil.createInsertBefore(
         5,
+        5,
         "text",
         tokenStreamRewriter
     );


### PR DESCRIPTION
There were some issues related to public modifier injection that were introduced by sampottinger#37, causing a large number of sketches to fail. This impacts sampottinger#15 and does not impact but is related to #5753. To prevent regressions, also introduces JDT based tests to ensure edits are valid.