### PR TITLE
Fix FX2D fullScreen from #5753 for sampottinger/master.

### DIFF
--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -315,14 +315,14 @@ public class PSurfaceFX implements PSurface {
       int sketchHeight = sketch.sketchHeight();
 
       if (fullScreen || spanDisplays) {
-        sketchWidth = (int) (screenRect.getWidth() / uiScale);
-        sketchHeight = (int) (screenRect.getHeight() / uiScale);
+        sketchWidth = (int) screenRect.getWidth();
+        sketchHeight = (int) screenRect.getHeight();
 
         stage.initStyle(StageStyle.UNDECORATED);
-        stage.setX(screenRect.getMinX() / uiScale);
-        stage.setY(screenRect.getMinY() / uiScale);
-        stage.setWidth(screenRect.getWidth() / uiScale);
-        stage.setHeight(screenRect.getHeight() / uiScale);
+        stage.setX(screenRect.getMinX());
+        stage.setY(screenRect.getMinY());
+        stage.setWidth(screenRect.getWidth());
+        stage.setHeight(screenRect.getHeight());
       }
 
       Canvas canvas = surface.canvas;


### PR DESCRIPTION
Due to changes in native pixel scaling in Java 11 and OpenJFX 11, fullScreen did not scale the surface to the correct size. This fixes fullScreen mode when using the FX2D renderer. Relates to processing#5753.