### PR TITLE
[antlr] Allow PdePreprocessor clients to specify code folder imports flexibly.

### DIFF
--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -96,7 +96,15 @@ public class PdePreprocessor {
     ArrayList<String> codeFolderImports = new ArrayList<>();
     if (codeFolderPackages != null) {
       for (String item : codeFolderPackages) {
-        codeFolderImports.add(item + ".*");
+        String fullItem;
+
+        if (item.endsWith(".*")) {
+          fullItem = item;
+        } else {
+          fullItem = item + ".*";
+        }
+
+        codeFolderImports.add(fullItem);
       }
     }
 


### PR DESCRIPTION
Allow PdePreprocessor clients to provide code folder imports with and without the wildcard appended, offering some abstraction to client code both within Processing itself and by outside users.