### PR TITLE
Use UTF8 in writing preprocessor result

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -24,6 +24,7 @@ Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 package processing.mode.java;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;

--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -229,7 +229,7 @@ public class JavaBuild {
       outputFolder.mkdirs();
 //      Base.openFolder(outputFolder);
       final File java = new File(outputFolder, sketch.getName() + ".java");
-      final PrintWriter stream = new PrintWriter(new FileWriter(java));
+      final PrintWriter stream = new PrintWriter(new FileWriter(java, StandardCharsets.UTF_8));
       try {
         result = preprocessor.write(
             stream,


### PR DESCRIPTION
Fix handling of unicode characters after preprocessor.

Incorporates @dzaima feedback to address issue reported by @anonymix007 regarding the treatment of unicode characters through the preprocessor as raised in #15 discussion.