### PR TITLE
Clean up comments

### DIFF
--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -389,9 +389,9 @@ public class Commander implements RunnerListener {
     out.println("--no-java            Do not embed Java. Use at your own risk!");
     out.println("--platform           Specify the platform (export to application only).");
     out.println("                     Should be one of 'windows', 'macosx', or 'linux'.");
-//    out.addEmptyLine("--bits               Must be specified if libraries are used that are");
-//    out.addEmptyLine("                     32- or 64-bit specific such as the OpenGL library.");
-//    out.addEmptyLine("                     Otherwise specify 0 or leave it out.");
+//    out.println("--bits               Must be specified if libraries are used that are");
+//    out.println("                     32- or 64-bit specific such as the OpenGL library.");
+//    out.println("                     Otherwise specify 0 or leave it out.");
 
     out.println();
     out.println("The --build, --run, --present, or --export must be the final parameter");

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -76,11 +76,11 @@ public class Compiler {
       "-nowarn", // we're not currently interested in warnings (works in ecj)
       "-d", build.getBinFolder().getAbsolutePath() // output the classes in the buildPath
     };
-    //PApplet.addEmptyLine(baseCommand);
+    //PApplet.println(baseCommand);
 
     String[] sourceFiles = Util.listFiles(build.getSrcFolder(), false, ".java");
     String[] command = PApplet.concat(baseCommand, sourceFiles);
-    //PApplet.addEmptyLine(command);
+    //PApplet.println(command);
 
     try {
       // Load errors into a local StringBuilder
@@ -131,7 +131,7 @@ public class Compiler {
 
       BufferedReader reader =
         new BufferedReader(new StringReader(errorBuffer.toString()));
-      //System.err.addEmptyLine(errorBuffer.toString());
+      //System.err.println(errorBuffer.toString());
 
       String line = null;
       while ((line = reader.readLine()) != null) {
@@ -141,9 +141,9 @@ public class Compiler {
         // and at least the first line of the error message
         String errorFormat = "([\\w\\d_]+.java):(\\d+):\\s*(.*):\\s*(.*)\\s*";
         String[] pieces = PApplet.match(line, errorFormat);
-        //PApplet.addEmptyLine(pieces);
+        //PApplet.println(pieces);
 
-        // if it's something unexpected, die and addCode the mess to the console
+        // if it's something unexpected, die and print the mess to the console
         if (pieces == null) {
           exception = new SketchException("Cannot parse error text: " + line);
           exception.hideStackTrace();
@@ -180,7 +180,7 @@ public class Compiler {
           String[] m = PApplet.match(errorMessage, "The import (.*) cannot be resolved");
           //what = what.substring(0, what.indexOf(' '));
           if (m != null) {
-//            System.out.addEmptyLine("'" + m[1] + "'");
+//            System.out.println("'" + m[1] + "'");
             if (m[1].equals("processing.xml")) {
               exception.setMessage("processing.xml no longer exists, this code needs to be updated for 2.0.");
               System.err.println("The processing.xml library has been replaced " +
@@ -225,7 +225,7 @@ public class Compiler {
 
         } else if (errorMessage.endsWith("cannot be resolved")) {
           // xxx cannot be resolved
-          //addEmptyLine(xxx);
+          //println(xxx);
 
           String what = errorMessage.substring(0, errorMessage.indexOf(' '));
 

--- a/java/src/processing/mode/java/Debugger.java
+++ b/java/src/processing/mode/java/Debugger.java
@@ -497,11 +497,11 @@ public class Debugger {
 //  /** Print a list of currently set breakpoints. */
 //  public synchronized void listBreakpoints() {
 //    if (breakpoints.isEmpty()) {
-//      System.out.addEmptyLine("no breakpoints");
+//      System.out.println("no breakpoints");
 //    } else {
-//      System.out.addEmptyLine("line breakpoints:");
+//      System.out.println("line breakpoints:");
 //      for (LineBreakpoint bp : breakpoints) {
-//        System.out.addEmptyLine(bp);
+//        System.out.println(bp);
 //      }
 //    }
 //  }
@@ -692,7 +692,7 @@ public class Debugger {
       List<StackFrame> frames = currentThread.frames();
       if (frames.size() > 1) {
         if (locationIsVisible(frames.get(1).location())) {
-          //System.out.addEmptyLine("stepping out to: " + locationToString(frames.get(1).location()));
+          //System.out.println("stepping out to: " + locationToString(frames.get(1).location()));
           stepOut();
           return;
         }
@@ -740,7 +740,7 @@ public class Debugger {
 
   /**
    * Print call stack trace of a thread. Only works on suspended threads.
-   * @param t suspended thread to addCode stack trace of
+   * @param t suspended thread to print stack trace of
    */
   protected void printStackTrace(ThreadReference t) {
     if (!t.isSuspended()) {
@@ -794,7 +794,7 @@ public class Debugger {
   /**
    * Print info about a thread. Includes name, status, isSuspended,
    * isAtBreakpoint.
-   * @param t the thread to addCode info about
+   * @param t the thread to print info about
    */
   protected void printThread(ThreadReference t) {
     System.out.println(t.name());
@@ -896,7 +896,7 @@ public class Debugger {
         javax.swing.SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
-            //System.out.addEmptyLine("updating vi. from EDT: " + javax.swing.SwingUtilities.isEventDispatchThread());
+            //System.out.println("updating vi. from EDT: " + javax.swing.SwingUtilities.isEventDispatchThread());
             vi.updateCallStack(stackTrace, "Call Stack");
             vi.updateLocals(locals, "Locals at " + currentLocation);
             vi.updateThisFields(thisFields, "Class " + thisName);
@@ -974,13 +974,13 @@ public class Debugger {
    * @return the list of current locals
    */
   protected List<VariableNode> getLocals(ThreadReference t, int depth) {
-    //System.out.addEmptyLine("getting locals");
+    //System.out.println("getting locals");
     List<VariableNode> vars = new ArrayList<>();
     try {
       if (t.frameCount() > 0) {
         StackFrame sf = t.frame(0);
         for (LocalVariable lv : sf.visibleVariables()) {
-          //System.out.addEmptyLine("local var: " + lv.name());
+          //System.out.println("local var: " + lv.name());
           Value val = sf.getValue(lv);
           VariableNode var = new LocalVariableNode(lv.name(), lv.typeName(), val, lv, sf);
           if (depth > 0) {
@@ -1163,11 +1163,11 @@ public class Debugger {
 
   /**
    * Print source code snippet.
-   * @param l {@link Location} object to addCode source code for
+   * @param l {@link Location} object to print source code for
    */
   protected void printSourceLocation(Location l) {
     try {
-      //System.out.addEmptyLine(l.sourceName() + ":" + l.lineNumber());
+      //System.out.println(l.sourceName() + ":" + l.lineNumber());
       System.out.println("in method " + l.method() + ":");
       System.out.println(getSourceLine(l.sourcePath(), l.lineNumber(), 2));
 
@@ -1189,7 +1189,7 @@ public class Debugger {
       loge("invalid line number: " + lineNo, null);
       return "";
     }
-    //System.out.addEmptyLine("getting line: " + lineNo);
+    //System.out.println("getting line: " + lineNo);
     File f = new File(srcPath + File.separator + filePath);
     String output = "";
     try {
@@ -1213,7 +1213,7 @@ public class Debugger {
       return output;
 
     } catch (FileNotFoundException ex) {
-      //System.err.addEmptyLine(ex);
+      //System.err.println(ex);
       return f.getName() + ":" + lineNo;
 
     } catch (IOException ex) {
@@ -1226,7 +1226,7 @@ public class Debugger {
   /**
    * Print info about a ReferenceType. Prints class name, source file name,
    * lists methods.
-   * @param rt the reference type to addCode out
+   * @param rt the reference type to print out
    */
   protected void printType(ReferenceType rt) {
     System.out.println("ref.type: " + rt);
@@ -1375,13 +1375,13 @@ public class Debugger {
       runtimeLineChanges.put(old, tracked);
     }
     runtimeTabsTracked.add(tab.getFileName());
-    //System.out.addEmptyLine("tracking tab: " + tab.getFileName());
+    //System.out.println("tracking tab: " + tab.getFileName());
   }
 
 
   /** Stop tracking line changes in all tabs. */
   protected void stopTrackingLineChanges() {
-    //System.out.addEmptyLine("stop tracking line changes");
+    //System.out.println("stop tracking line changes");
     for (LineID tracked : runtimeLineChanges.values()) {
       tracked.stopTracking();
     }
@@ -1456,7 +1456,7 @@ public class Debugger {
         while (true) {
           EventSet eventSet = eventQueue.remove();
           listener.vmEvent(eventSet);
-          // for (Event e : eventSet) { System.out.addEmptyLine("VM Event: " + e.toString()); }
+          // for (Event e : eventSet) { System.out.println("VM Event: " + e.toString()); }
         }
       } catch (VMDisconnectedException e) {
         Messages.log("VMEventReader quit on VM disconnect");

--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -157,7 +157,7 @@ public class JavaBuild {
     // make sure the user isn't playing "hide the sketch folder"
     sketch.ensureExistence();
 
-//    System.out.addEmptyLine("srcFolder is " + srcFolder);
+//    System.out.println("srcFolder is " + srcFolder);
     classPath = binFolder.getAbsolutePath();
 
     // figure out the contents of the code folder to see if there
@@ -496,7 +496,7 @@ public class JavaBuild {
     int codeLine = -1;
 
     //System.out.println(message + " placing " + dotJavaFilename + " " + dotJavaLine);
-    //System.out.addEmptyLine("code count is " + getCodeCount());
+    //System.out.println("code count is " + getCodeCount());
 
     // first check to see if it's a .java file
     for (int i = 0; i < sketch.getCodeCount(); i++) {
@@ -526,7 +526,7 @@ public class JavaBuild {
         //System.out.println("looking for line " + dotJavaLine);
         if (code.getPreprocOffset() <= dotJavaLine) {
           codeIndex = i;
-//          System.out.addEmptyLine("i'm thinkin file " + i);
+//          System.out.println("i'm thinkin file " + i);
           codeLine = dotJavaLine - code.getPreprocOffset();
         }
       }
@@ -976,7 +976,7 @@ public class JavaBuild {
       pw.print("APPDIR=$(dirname \"$APPDIR\")\n");  // more POSIX compliant
 
       // another fix for bug #234, LD_LIBRARY_PATH ignored on some platforms
-      //ps.addCode("LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$APPDIR\n");
+      //ps.print("LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$APPDIR\n");
 
       if (embedJava) {
         // https://github.com/processing/processing/issues/2349
@@ -1121,7 +1121,7 @@ public class JavaBuild {
     if (!path.endsWith("/") && !path.endsWith("\\")) {
       path += '/';
     }
-//    System.out.addEmptyLine("path is " + path);
+//    System.out.println("path is " + path);
     addClasses(zos, dir, path);
   }
 
@@ -1134,13 +1134,13 @@ public class JavaBuild {
     });
     for (File sub : files) {
       String relativePath = sub.getAbsolutePath().substring(rootPath.length());
-//      System.out.addEmptyLine("relative path is " + relativePath);
+//      System.out.println("relative path is " + relativePath);
 
       if (sub.isDirectory()) {
         addClasses(zos, sub, rootPath);
 
       } else if (sub.getName().endsWith(".class")) {
-//        System.out.addEmptyLine("  adding item " + relativePath);
+//        System.out.println("  adding item " + relativePath);
         ZipEntry entry = new ZipEntry(relativePath);
         zos.putNextEntry(entry);
         //zos.write(Base.loadBytesRaw(sub));

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -84,7 +84,7 @@ public class JavaEditor extends Editor {
 
     // set breakpoints from marker comments
     for (LineID lineID : stripBreakpointComments()) {
-      //System.out.addEmptyLine("setting: " + lineID);
+      //System.out.println("setting: " + lineID);
       debugger.setBreakpoint(lineID);
     }
     // setting breakpoints will flag sketch as modified, so override this here
@@ -930,7 +930,7 @@ public class JavaEditor extends Editor {
       }
     });
     dialog.pack();
-//    System.out.addEmptyLine("after pack: " + panel.getPreferredSize());
+//    System.out.println("after pack: " + panel.getPreferredSize());
 //    dialog.setSize(optionPane.getPreferredSize());
     dialog.setResizable(false);
 
@@ -1190,19 +1190,19 @@ public class JavaEditor extends Editor {
 
 
   public boolean handleSaveAs() {
-    //System.out.addEmptyLine("handleSaveAs");
+    //System.out.println("handleSaveAs");
     String oldName = getSketch().getCode(0).getFileName();
-    //System.out.addEmptyLine("old name: " + oldName);
+    //System.out.println("old name: " + oldName);
     boolean saved = super.handleSaveAs();
     if (saved) {
       // re-set breakpoints in first tab (name has changed)
       List<LineBreakpoint> bps = debugger.getBreakpoints(oldName);
       debugger.clearBreakpoints(oldName);
       String newName = getSketch().getCode(0).getFileName();
-      //System.out.addEmptyLine("new name: " + newName);
+      //System.out.println("new name: " + newName);
       for (LineBreakpoint bp : bps) {
         LineID line = new LineID(newName, bp.lineID().lineIdx());
-        //System.out.addEmptyLine("setting: " + line);
+        //System.out.println("setting: " + line);
         debugger.setBreakpoint(line);
       }
       // add breakpoint marker comments to source file
@@ -1311,7 +1311,7 @@ public class JavaEditor extends Editor {
    */
   @Override
   public void dispose() {
-    //System.out.addEmptyLine("window dispose");
+    //System.out.println("window dispose");
     // quit running debug session
     if (debugEnabled) {
       debugger.stopDebug();
@@ -1560,16 +1560,16 @@ public class JavaEditor extends Editor {
       SketchCode tab = sketch.getCode(i);
       String code = tab.getProgram();
       String lines[] = code.split("\\r?\\n"); // newlines not included
-      //System.out.addEmptyLine(code);
+      //System.out.println(code);
 
       // scan code for breakpoint comments
       int lineIdx = 0;
       for (String line : lines) {
-        //System.out.addEmptyLine(line);
+        //System.out.println(line);
         if (line.endsWith(breakpointMarkerComment)) {
           LineID lineID = new LineID(tab.getFileName(), lineIdx);
           bps.add(lineID);
-          //System.out.addEmptyLine("found breakpoint: " + lineID);
+          //System.out.println("found breakpoint: " + lineID);
           // got a breakpoint
           //dbg.setBreakpoint(lineID);
           int index = line.lastIndexOf(breakpointMarkerComment);
@@ -1606,18 +1606,18 @@ public class JavaEditor extends Editor {
     // load the source file
     ////switched to using methods provided by the SketchCode class
     // File sourceFile = new File(sketch.getFolder(), tab.getFileName());
-    //System.out.addEmptyLine("file: " + sourceFile);
+    //System.out.println("file: " + sourceFile);
     try {
       tab.load();
       String code = tab.getProgram();
-      //System.out.addEmptyLine("code: " + code);
+      //System.out.println("code: " + code);
       String lines[] = code.split("\\r?\\n"); // newlines not included
       for (LineBreakpoint bp : bps) {
-        //System.out.addEmptyLine("adding bp: " + bp.lineID());
+        //System.out.println("adding bp: " + bp.lineID());
         lines[bp.lineID().lineIdx()] += breakpointMarkerComment;
       }
       code = PApplet.join(lines, "\n");
-      //System.out.addEmptyLine("new code: " + code);
+      //System.out.println("new code: " + code);
       tab.setProgram(code);
       tab.save();
     } catch (IOException ex) {
@@ -1839,7 +1839,7 @@ public class JavaEditor extends Editor {
         if (library == null) {
           Contribution c = importMap.get(importHeaders);
           if (c != null && c instanceof AvailableContribution) {
-            libList.add((AvailableContribution) c);// System.out.addEmptyLine(importHeaders
+            libList.add((AvailableContribution) c);// System.out.println(importHeaders
                                                    // + "not found");
           }
         }
@@ -1847,7 +1847,7 @@ public class JavaEditor extends Editor {
         // Not gonna happen (hopefully)
         Contribution c = importMap.get(importHeaders);
         if (c != null && c instanceof AvailableContribution) {
-          libList.add((AvailableContribution) c);// System.out.addEmptyLine(importHeaders
+          libList.add((AvailableContribution) c);// System.out.println(importHeaders
                                                  // + "not found");
         }
       }
@@ -2125,7 +2125,7 @@ public class JavaEditor extends Editor {
    */
   public void removeBreakpointedLine(int lineIdx) {
     LineID line = getLineIDInCurrentTab(lineIdx);
-    //System.out.addEmptyLine("line id: " + line.fileName() + " " + line.lineIdx());
+    //System.out.println("line id: " + line.fileName() + " " + line.lineIdx());
     LineHighlight foundLine = null;
     for (LineHighlight hl : breakpointedLines) {
       if (hl.getLineID().equals(line)) {
@@ -2204,7 +2204,7 @@ public class JavaEditor extends Editor {
   public void setCode(SketchCode code) {
     Document oldDoc = code.getDocument();
 
-    //System.out.addEmptyLine("tab switch: " + code.getFileName());
+    //System.out.println("tab switch: " + code.getFileName());
     // set the new document in the textarea, etc. need to do this first
     super.setCode(code);
 
@@ -2684,7 +2684,6 @@ public class JavaEditor extends Editor {
       }
     }
 
-
     // Copy current program to interactive program
     // modify the code below, replace all numbers with their variable names
     // loop through all tabs in the current sketch
@@ -2763,7 +2762,7 @@ public class JavaEditor extends Editor {
       TweakClient.getServerCode(port, numOfInts>0, numOfFloats>0);
     code[0].setProgram(header + c + serverCode);
 
-    // addCode out modified code
+    // print out modified code
     String showModCode = Preferences.get(PREF_TWEAK_SHOW_CODE);
     if (showModCode == null) {
       Preferences.setBoolean(PREF_TWEAK_SHOW_CODE, false);

--- a/java/src/processing/mode/java/JavaInputHandler.java
+++ b/java/src/processing/mode/java/JavaInputHandler.java
@@ -84,9 +84,9 @@ public class JavaInputHandler extends PdeInputHandler {
       int caretIndex = textarea.getCaretPosition();
 
       int index = calcLineStart(caretIndex - 1, contents);
-      //System.out.addEmptyLine("line start " + (int) contents[index]);
+      //System.out.println("line start " + (int) contents[index]);
       index -= 2;  // step over the newline
-      //System.out.addEmptyLine((int) contents[index]);
+      //System.out.println((int) contents[index]);
       boolean onlySpaces = true;
       while (index > 0) {
         if (contents[index] == 10) {

--- a/java/src/processing/mode/java/JavaMode.java
+++ b/java/src/processing/mode/java/JavaMode.java
@@ -101,7 +101,7 @@ public class JavaMode extends Mode {
       coreLibrary = new Library(coreFolder);
 //      try {
 //        coreLibrary = getLibrary("processing.core");
-//        System.out.addEmptyLine("core found at " + coreLibrary.getLibraryPath());
+//        System.out.println("core found at " + coreLibrary.getLibraryPath());
 //      } catch (SketchException e) {
 //        Base.log("Serious problem while locating processing.core", e);
 //      }

--- a/java/src/processing/mode/java/JavaToolbar.java
+++ b/java/src/processing/mode/java/JavaToolbar.java
@@ -54,7 +54,7 @@ public class JavaToolbar extends EditorToolbar {
   public List<EditorButton> createButtons() {
     // jeditor not ready yet because this is called by super()
     final boolean debug = ((JavaEditor) editor).isDebuggerEnabled();
-//    System.out.addEmptyLine("creating buttons in JavaToolbar, debug:" + debug);
+//    System.out.println("creating buttons in JavaToolbar, debug:" + debug);
     List<EditorButton> outgoing = new ArrayList<>();
 
     final String runText = debug ?

--- a/java/src/processing/mode/java/VariableInspector.java
+++ b/java/src/processing/mode/java/VariableInspector.java
@@ -241,8 +241,8 @@ public class VariableInspector extends JDialog {
     valueColumn.setCellRenderer(new ValueCellRenderer());
     valueColumn.setCellEditor(new ValueCellEditor());
 
-    //System.out.addEmptyLine("renderer: " + tree.getDefaultRenderer(String.class).getClass());
-    //System.out.addEmptyLine("editor: " + tree.getDefaultEditor(String.class).getClass());
+    //System.out.println("renderer: " + tree.getDefaultRenderer(String.class).getClass());
+    //System.out.println("editor: " + tree.getDefaultEditor(String.class).getClass());
 
     callStack = new ArrayList<>();
     locals = new ArrayList<>();
@@ -383,7 +383,7 @@ public class VariableInspector extends JDialog {
     public boolean isCellEditable(Object o, int i) {
       if (i == 0 && o instanceof VariableNode) {
         VariableNode var = (VariableNode) o;
-        //System.out.addEmptyLine("type: " + var.getTypeName());
+        //System.out.println("type: " + var.getTypeName());
         for (int type : editableTypes) {
           if (var.getType() == type) {
             return true;
@@ -666,7 +666,7 @@ public class VariableInspector extends JDialog {
 
     @Override
     public void treeWillExpand(TreeExpansionEvent tee) throws ExpandVetoException {
-      //System.out.addEmptyLine("will expand");
+      //System.out.println("will expand");
       Object last = tee.getPath().getLastPathComponent();
       if (!(last instanceof VariableNode)) {
         return;
@@ -683,7 +683,7 @@ public class VariableInspector extends JDialog {
 
     @Override
     public void treeExpanded(TreeExpansionEvent tee) {
-      //System.out.addEmptyLine("expanded: " + tee.getPath());
+      //System.out.println("expanded: " + tee.getPath());
       if (!expandedNodes.contains(tee.getPath())) {
         expandedNodes.add(tee.getPath());
       }
@@ -691,7 +691,7 @@ public class VariableInspector extends JDialog {
 
     @Override
     public void treeCollapsed(TreeExpansionEvent tee) {
-      //System.out.addEmptyLine("collapsed: " + tee.getPath());
+      //System.out.println("collapsed: " + tee.getPath());
 
       // first remove all children of collapsed path
       // this makes sure children do not appear before parents in the list.
@@ -711,7 +711,7 @@ public class VariableInspector extends JDialog {
 
     @Override
     public void treeExpansionVetoed(TreeExpansionEvent tee, ExpandVetoException eve) {
-      //System.out.addEmptyLine("expansion vetoed");
+      //System.out.println("expansion vetoed");
       // nop
     }
   }
@@ -855,12 +855,12 @@ public class VariableInspector extends JDialog {
 
     // handle node expansions
     for (TreePath path : expandedNodes) {
-      //System.out.addEmptyLine("re-expanding: " + path);
+      //System.out.println("re-expanding: " + path);
       path = synthesizePath(path);
       if (path != null) {
         tree.expandPath(path);
       } else {
-        //System.out.addEmptyLine("couldn't synthesize path");
+        //System.out.println("couldn't synthesize path");
       }
     }
 
@@ -877,7 +877,7 @@ public class VariableInspector extends JDialog {
    * @return the rebuilt path, usable on the current tree.
    */
   protected TreePath synthesizePath(TreePath path) {
-    //System.out.addEmptyLine("synthesizing: " + path);
+    //System.out.println("synthesizing: " + path);
     if (path.getPathCount() == 0 || !rootNode.equals(path.getPathComponent(0))) {
       return null;
     }
@@ -891,12 +891,12 @@ public class VariableInspector extends JDialog {
         if (nextNode.equals(path.getPathComponent(i + 1))) {
           currentNode = nextNode;
           newPath[i + 1] = nextNode;
-          //System.out.addEmptyLine("found node " + (i+1) + ": " + nextNode);
+          //System.out.println("found node " + (i+1) + ": " + nextNode);
           break;
         }
       }
       if (newPath[i + 1] == null) {
-        //System.out.addEmptyLine("didn't find node");
+        //System.out.println("didn't find node");
         return null;
       }
     }

--- a/java/src/processing/mode/java/debug/LineBreakpoint.java
+++ b/java/src/processing/mode/java/debug/LineBreakpoint.java
@@ -182,7 +182,7 @@ public class LineBreakpoint implements ClassLoadListener {
    */
   public void remove() {
     dbg.removeClassLoadListener(this);
-    //System.out.addEmptyLine("removing " + line.lineIdx());
+    //System.out.println("removing " + line.lineIdx());
     dbg.getEditor().removeBreakpointedLine(line.lineIdx());
     if (dbg.isPaused()) {
       // immediately remove the breakpoint

--- a/java/src/processing/mode/java/debug/LineID.java
+++ b/java/src/processing/mode/java/debug/LineID.java
@@ -131,7 +131,7 @@ public class LineID implements DocumentListener {
    * @param doc the {@link Document} to use for line number tracking
    */
   public synchronized void startTracking(Document doc) {
-    //System.out.addEmptyLine("tracking: " + this);
+    //System.out.println("tracking: " + this);
     if (doc == null) {
       return; // null arg
     }
@@ -240,10 +240,10 @@ public class LineID implements DocumentListener {
    * is edited. This happens when text is inserted or removed.
    */
   protected void editEvent(DocumentEvent de) {
-    //System.out.addEmptyLine("document edit @ " + de.getCharPosition());
+    //System.out.println("document edit @ " + de.getCharPosition());
     if (de.getOffset() <= pos.getOffset()) {
       updatePosition();
-      //System.out.addEmptyLine("updating, new line no: " + lineNo);
+      //System.out.println("updating, new line no: " + lineNo);
     }
   }
 

--- a/java/src/processing/mode/java/debug/VariableNode.java
+++ b/java/src/processing/mode/java/debug/VariableNode.java
@@ -354,15 +354,15 @@ public class VariableNode implements MutableTreeNode {
     }
     final VariableNode other = (VariableNode) obj;
     if ((this.type == null) ? (other.type != null) : !this.type.equals(other.type)) {
-      //System.out.addEmptyLine("type not equal");
+      //System.out.println("type not equal");
       return false;
     }
     if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
-      //System.out.addEmptyLine("name not equal");
+      //System.out.println("name not equal");
       return false;
     }
     if (this.value != other.value && (this.value == null || !this.value.equals(other.value))) {
-      //System.out.addEmptyLine("value not equal");
+      //System.out.println("value not equal");
       return false;
     }
     return true;

--- a/java/src/processing/mode/java/pdex/CompletionCandidate.java
+++ b/java/src/processing/mode/java/pdex/CompletionCandidate.java
@@ -216,7 +216,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate> {
 
 
   boolean startsWith(String newWord) {
-//    System.out.addEmptyLine("checking " + newWord);
+//    System.out.println("checking " + newWord);
 //    return getNoHtmlLabel().toLowerCase().startsWith(newWord);
     // this seems to be elementName in all cases [fry 180326]
     return elementName.startsWith(newWord);

--- a/java/src/processing/mode/java/pdex/CompletionGenerator.java
+++ b/java/src/processing/mode/java/pdex/CompletionGenerator.java
@@ -841,7 +841,7 @@ public class CompletionGenerator {
       if (prop.isChildProperty() || prop.isSimpleProperty()) {
         if (node.getStructuralProperty(prop) != null) {
 //          System.out
-//              .addEmptyLine(node.getStructuralProperty(prop) + " -> " + (prop));
+//              .println(node.getStructuralProperty(prop) + " -> " + (prop));
           if (node.getStructuralProperty(prop) instanceof ASTNode) {
             ASTNode cnode = (ASTNode) node.getStructuralProperty(prop);
 //            log("Looking at " + getNodeAsString(cnode)+ " for line num " + lineNumber);
@@ -1093,7 +1093,7 @@ public class CompletionGenerator {
 //    else if(findMe instanceof QualifiedName){
 //      QualifiedName qn = (QualifiedName) findMe;
 //      System.out
-//          .addEmptyLine("findMe is a QN, "
+//          .println("findMe is a QN, "
 //              + (qn.getQualifier().toString() + " other " + qn.getName()
 //                  .toString()));
 //    }
@@ -1530,9 +1530,9 @@ public class CompletionGenerator {
 //      log("Looking at " + getNodeAsString(node) + " for " + name
 //          + " in definedIn");
       if (!constrains.contains(node.getNodeType()) && constrains.size() > 0) {
-//        System.err.addCode("definedIn -1 " + " But constrain was ");
+//        System.err.print("definedIn -1 " + " But constrain was ");
 //        for (Integer integer : constrains) {
-//          System.out.addCode(ASTNode.nodeClassForType(integer) + ",");
+//          System.out.print(ASTNode.nodeClassForType(integer) + ",");
 //        }
 //        log();
         return null;
@@ -2028,18 +2028,18 @@ public class CompletionGenerator {
       Elements elm = doc.getElementsByClass("ref-item");
       String msg = "";
       String methodName = docFile.getName().substring(0, docFile.getName().indexOf('_'));
-      //System.out.addEmptyLine(methodName);
+      //System.out.println(methodName);
       for (org.jsoup.nodes.Element ele : elm) {
         msg = "<html><body> <strong><div style=\"width: 300px; text-justification: justify;\"></strong><table cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"ref-item\">"
             + ele.html() + "</table></div></html></body></html>";
         //mat.replaceAll("");
         msg = msg.replaceAll("img src=\"", "img src=\""
             + referenceFolder.toURI().toURL().toString() + "/");
-        //System.out.addEmptyLine(ele.text());
+        //System.out.println(ele.text());
       }
       jdocMap.put(methodName, msg);
     }
-    //System.out.addEmptyLine("JDoc loaded " + jdocMap.size());
+    //System.out.println("JDoc loaded " + jdocMap.size());
   }
 
 

--- a/java/src/processing/mode/java/runner/MessageSiphon.java
+++ b/java/src/processing/mode/java/runner/MessageSiphon.java
@@ -57,11 +57,11 @@ public class MessageSiphon implements Runnable {
       String currentLine;
       while ((currentLine = streamReader.readLine()) != null) {
         // \n is added again because readLine() strips it out
-        //EditorConsole.systemOut.addEmptyLine("messaging in");
+        //EditorConsole.systemOut.println("messaging in");
         consumer.message(currentLine + "\n");
-        //EditorConsole.systemOut.addEmptyLine("messaging out");
+        //EditorConsole.systemOut.println("messaging out");
       }
-      //EditorConsole.systemOut.addEmptyLine("messaging thread done");
+      //EditorConsole.systemOut.println("messaging thread done");
       thread = null;
 
     } catch (NullPointerException npe) {
@@ -76,7 +76,7 @@ public class MessageSiphon implements Runnable {
       if ((mess != null) &&
           (mess.indexOf("Bad file descriptor") != -1)) {
         //if (e.getMessage().indexOf("Bad file descriptor") == -1) {
-        //System.err.addEmptyLine("MessageSiphon err " + e);
+        //System.err.println("MessageSiphon err " + e);
         //e.printStackTrace();
       } else {
         e.printStackTrace();

--- a/java/src/processing/mode/java/runner/MessageStream.java
+++ b/java/src/processing/mode/java/runner/MessageStream.java
@@ -51,7 +51,7 @@ class MessageStream extends OutputStream {
   }
 
   public void write(byte b[], int offset, int length) {
-    //System.out.addEmptyLine("leech2: " + new String(b));
+    //System.out.println("leech2: " + new String(b));
     this.messageConsumer.message(new String(b, offset, length));
   }
 

--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -233,7 +233,7 @@ public class Runner implements MessageConsumer {
 
     AttachingConnector connector = (AttachingConnector)
       findConnector("com.sun.jdi.SocketAttach");
-    //PApplet.addEmptyLine(connector);  // gets the defaults
+    //PApplet.println(connector);  // gets the defaults
 
     Map<String, Argument> arguments = connector.defaultArguments();
 
@@ -247,11 +247,11 @@ public class Runner implements MessageConsumer {
 //      (Connector.Argument)arguments.get("timeout");
 //    timeoutArg.setValue("10000");
 
-    //PApplet.addEmptyLine(connector);  // prints the current
+    //PApplet.println(connector);  // prints the current
     //com.sun.tools.jdi.AbstractLauncher al;
     //com.sun.tools.jdi.RawCommandLineLauncher rcll;
 
-    //System.out.addEmptyLine(PApplet.javaVersion);
+    //System.out.println(PApplet.javaVersion);
     // http://java.sun.com/j2se/1.5.0/docs/guide/jpda/conninv.html#sunlaunch
 
     try {
@@ -280,7 +280,7 @@ public class Runner implements MessageConsumer {
           // This will fire ConnectException (socket not available) until
           // the VM finishes starting up and opens its socket for us.
           Messages.log(getClass().getName() + " socket for VM not ready");
-//          System.out.addEmptyLine("waiting");
+//          System.out.println("waiting");
 //          e.printStackTrace();
           try {
             Thread.sleep(100);
@@ -367,7 +367,7 @@ public class Runner implements MessageConsumer {
     // enable assertions
     // http://dev.processing.org/bugs/show_bug.cgi?id=1188
     params.append("-ea");
-    //PApplet.addEmptyLine(PApplet.split(sketch.classPath, ':'));
+    //PApplet.println(PApplet.split(sketch.classPath, ':'));
 
     return params;
   }
@@ -499,20 +499,20 @@ public class Runner implements MessageConsumer {
   protected void launchJava(final String[] args) {
     new Thread(new Runnable() {
       public void run() {
-//        PApplet.addEmptyLine("java starting");
+//        PApplet.println("java starting");
         vmReturnedError = false;
         process = PApplet.exec(args);
         try {
-//          PApplet.addEmptyLine("java waiting");
+//          PApplet.println("java waiting");
           int result = process.waitFor();
-//          PApplet.addEmptyLine("java done waiting");
+//          PApplet.println("java done waiting");
           if (result != 0) {
             String[] errorStrings = PApplet.loadStrings(process.getErrorStream());
             String[] inputStrings = PApplet.loadStrings(process.getInputStream());
 
-//            PApplet.addEmptyLine("launchJava stderr:");
-//            PApplet.addEmptyLine(errorStrings);
-//            PApplet.addEmptyLine("launchJava stdout:");
+//            PApplet.println("launchJava stderr:");
+//            PApplet.println(errorStrings);
+//            PApplet.println("launchJava stdout:");
             PApplet.printArray(inputStrings);
 
             if (errorStrings != null && errorStrings.length > 1) {
@@ -594,12 +594,12 @@ public class Runner implements MessageConsumer {
 //            listener.vmEvent(eventSet);
 
             for (Event event : eventSet) {
-//              System.out.addEmptyLine("EventThread.handleEvent -> " + event);
+//              System.out.println("EventThread.handleEvent -> " + event);
               if (event instanceof VMStartEvent) {
                 vm.resume();
               } else if (event instanceof ExceptionEvent) {
 //                for (ThreadReference thread : vm.allThreads()) {
-//                  System.out.addEmptyLine("thread : " + thread);
+//                  System.out.println("thread : " + thread);
 ////                  thread.suspend();
 //                }
                 exceptionEvent((ExceptionEvent) event);
@@ -633,13 +633,13 @@ public class Runner implements MessageConsumer {
     try {
       if (eventThread != null) eventThread.join();  // is this the problem?
 
-//      System.out.addEmptyLine("in here");
+//      System.out.println("in here");
       // Bug #852 tracked to this next line in the code.
       // http://dev.processing.org/bugs/show_bug.cgi?id=852
       errThread.join(); // Make sure output is forwarded
-//      System.out.addEmptyLine("and then");
+//      System.out.println("and then");
       outThread.join(); // before we exit
-//      System.out.addEmptyLine("finished join for errThread and outThread");
+//      System.out.println("finished join for errThread and outThread");
 
       // At this point, disable the run button.
       // This happens when the sketch is exited by hitting ESC,
@@ -653,7 +653,7 @@ public class Runner implements MessageConsumer {
     } catch (InterruptedException exc) {
       // we don't interrupt
     }
-    //System.out.addEmptyLine("and leaving");
+    //System.out.println("and leaving");
   }
 
 
@@ -667,12 +667,12 @@ public class Runner implements MessageConsumer {
 //    Iterator iter2 = connectors.iterator();
 //    while (iter2.hasNext()) {
 //      Connector connector = (Connector)iter2.next();
-//      System.out.addEmptyLine("connector name is " + connector.name());
+//      System.out.println("connector name is " + connector.name());
 //    }
 
     for (Object c : connectors) {
       Connector connector = (Connector) c;
-//      System.out.addEmptyLine(connector.name());
+//      System.out.println(connector.name());
 //    }
 //    Iterator iter = connectors.iterator();
 //    while (iter.hasNext()) {
@@ -694,9 +694,9 @@ public class Runner implements MessageConsumer {
     String exceptionName = rt.name();
     //Field messageField = Throwable.class.getField("detailMessage");
     Field messageField = rt.fieldByName("detailMessage");
-//    System.out.addEmptyLine("field " + messageField);
+//    System.out.println("field " + messageField);
     Value messageValue = or.getValue(messageField);
-//    System.out.addEmptyLine("mess val " + messageValue);
+//    System.out.println("mess val " + messageValue);
 
     //"java.lang.ArrayIndexOutOfBoundsException"
     int last = exceptionName.lastIndexOf('.');
@@ -708,7 +708,7 @@ public class Runner implements MessageConsumer {
       }
       message += ": " + messageStr;
     }
-//    System.out.addEmptyLine("mess type " + messageValue.type());
+//    System.out.println("mess type " + messageValue.type());
     //StringReference messageReference = (StringReference) messageValue.type();
 
     // First just report the exception and its placement
@@ -806,7 +806,7 @@ public class Runner implements MessageConsumer {
     try {
       // use to dump the stack for debugging
 //      for (StackFrame frame : thread.frames()) {
-//        System.out.addEmptyLine("frame: " + frame);
+//        System.out.println("frame: " + frame);
 //      }
 
       List<StackFrame> frames = thread.frames();
@@ -832,7 +832,7 @@ public class Runner implements MessageConsumer {
         }
       }
     } catch (IncompatibleThreadStateException e) {
-      // This shouldn't happen, but if it does, addCode the exception in case
+      // This shouldn't happen, but if it does, print the exception in case
       // it's something that needs to be debugged separately.
       e.printStackTrace(sketchErr);
     } catch (Exception e) {
@@ -864,11 +864,11 @@ public class Runner implements MessageConsumer {
         }
       }
 //      for (Method m : ((ClassType) or.referenceType()).allMethods()) {
-//        System.out.addEmptyLine(m + " | " + m.signature() + " | " + m.genericSignature());
+//        System.out.println(m + " | " + m.signature() + " | " + m.genericSignature());
 //      }
       // Implemented for 2.0b9, writes a stack trace when there's an internal error inside core.
       method = ((ClassType) or.referenceType()).concreteMethodByName("printStackTrace", "()V");
-//      System.err.addEmptyLine("got method " + method);
+//      System.err.println("got method " + method);
       or.invokeMethod(thread, method, new ArrayList<Value>(), ObjectReference.INVOKE_SINGLE_THREADED);
 
     } catch (Exception e) {
@@ -899,7 +899,7 @@ public class Runner implements MessageConsumer {
 
         } catch (com.sun.jdi.VMDisconnectedException vmde) {
           // if the vm has disconnected on its own, ignore message
-          //System.out.addEmptyLine("harmless disconnect " + vmde.getMessage());
+          //System.out.println("harmless disconnect " + vmde.getMessage());
           // TODO shouldn't need to do this, need to do more cleanup
         }
       }
@@ -911,15 +911,15 @@ public class Runner implements MessageConsumer {
   // attempted to remove synchronized for 0136 to fix bug #775 (no luck tho)
   // http://dev.processing.org/bugs/show_bug.cgi?id=775
   synchronized public void message(String s) {
-//    System.out.addEmptyLine("M" + s.length() + ":" + s.trim()); // + "MMM" + s.length());
+//    System.out.println("M" + s.length() + ":" + s.trim()); // + "MMM" + s.length());
 
     // this eats the CRLFs on the lines.. oops.. do it later
     //if (s.trim().length() == 0) return;
 
-    // this is PApplet sending a message (via System.out.addEmptyLine)
+    // this is PApplet sending a message (via System.out.println)
     // that signals that the applet has been quit.
     if (s.indexOf(PApplet.EXTERNAL_STOP) == 0) {
-      //System.out.addEmptyLine("external: quit");
+      //System.out.println("external: quit");
       if (editor != null) {
 //        editor.internalCloseRunner();  // [091124]
 //        editor.handleStop();  // prior to 0192
@@ -939,21 +939,21 @@ public class Runner implements MessageConsumer {
       int top = Integer.parseInt(nums.substring(space + 1));
       // this is only fired when connected to an editor
       editor.setSketchLocation(new Point(left, top));
-      //System.out.addEmptyLine("external: move to " + left + " " + top);
+      //System.out.println("external: move to " + left + " " + top);
       return;
     }
 
     // these are used for debugging, in case there are concerns
     // that some errors aren't coming through properly
 //    if (s.length() > 2) {
-//      System.err.addEmptyLine(newMessage);
-//      System.err.addEmptyLine("message " + s.length() + ":" + s);
+//      System.err.println(newMessage);
+//      System.err.println("message " + s.length() + ":" + s);
 //    }
 
     // always shove out the message, since it might not fall under
     // the same setup as we're expecting
     sketchErr.print(s);
-    //System.err.addEmptyLine("[" + s.length() + "] " + s);
+    //System.err.println("[" + s.length() + "] " + s);
     sketchErr.flush();
   }
 }

--- a/java/src/processing/mode/java/tweak/TweakClient.java
+++ b/java/src/processing/mode/java/tweak/TweakClient.java
@@ -139,7 +139,7 @@ public class TweakClient {
     "      socket = new DatagramSocket("+listenPort+");\n"+
     "      socket.setSoTimeout(250);\n"+
     "    } catch (IOException e) {\n"+
-    "      addEmptyLine(\"error: could not create TweakMode server socket\");\n"+
+    "      println(\"error: could not create TweakMode server socket\");\n"+
     "    }\n"+
     "  }\n"+
     "  public void run()\n"+

--- a/java/test/processing/mode/java/ProcessingTestUtil.java
+++ b/java/test/processing/mode/java/ProcessingTestUtil.java
@@ -28,7 +28,7 @@ public class ProcessingTestUtil {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    //System.err.addEmptyLine("ProcessingTestUtil initialized.");
+    //System.err.println("ProcessingTestUtil initialized.");
   }
 
   static String normalize(final Object s) {


### PR DESCRIPTION
Cleans up a probably accidental rename of `print` and `println` in comments & strings. Not sure whether the antlr branch is the correct one to target with this change.  
Overrides https://github.com/sampottinger/processing/pull/74.