### PR TITLE
Update travis to forgive brew install delay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 
 before_script:
   - cd build
-  - brew install ant
-  - brew install awscli
+  - travis_wait brew install ant
+  - travis_wait brew install awscli
 
 script:
   - ant clean


### PR DESCRIPTION
Update travis to forgive brew install taking a long time if it is being upgraded.