### PR TITLE
Bump memory for Processing and default sketch memory.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -775,7 +775,7 @@
       <option value="-Xms128M" />
       -->
       <!-- returning 140606 per PDE X request -->
-      <option value="-Xmx256M" />
+      <option value="-Xmx512M" />
 
       <option value="-Dapple.awt.application.name=Processing" />
 

--- a/build/linux/processing
+++ b/build/linux/processing
@@ -115,5 +115,5 @@ else
   fi
   cd "$APPDIR"
 
-  java -splash:lib/about-1x.png -Djna.nosys=true -Xmx256m processing.app.Base "$SKETCH" &
+  java -splash:lib/about-1x.png -Djna.nosys=true -Xmx512m processing.app.Base "$SKETCH" &
 fi

--- a/build/linux/processing
+++ b/build/linux/processing
@@ -104,7 +104,7 @@ cmd_name='processing-java'
 
 if [ $current_name = $cmd_name ]
 then
-    java -Djna.nosys=true -Xmx256m processing.mode.java.Commander "$@"
+    java -Djna.nosys=true -Xmx512m processing.mode.java.Commander "$@"
     exit $?
 else
   # Start Processing in the same directory as this script

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -195,7 +195,7 @@ run.options =
 # settings for the -XmsNNNm and -XmxNNNm command line option
 run.options.memory = false
 run.options.memory.initial = 64
-run.options.memory.maximum = 256
+run.options.memory.maximum = 512
 
 # By default, Mac OS X 10.6 launches applications in 32-bit mode, 
 # which is more compatible with libraries (many have not updated to 64-bit).

--- a/build/windows/config-cmd.xml
+++ b/build/windows/config-cmd.xml
@@ -37,7 +37,7 @@
     <!-- starting in 3.0, require Java 8 -->
     <minVersion>1.8.0_60</minVersion>
     <!-- increase available per PDE X request -->
-    <maxHeapSize>256</maxHeapSize>
+    <maxHeapSize>512</maxHeapSize>
   </jre>
 
   <messages>

--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -47,7 +47,7 @@
     <!-- starting in 3.0, require Java 8 -->
     <minVersion>1.8.0_60</minVersion>
     <!-- increase available per PDE X request -->
-    <maxHeapSize>256</maxHeapSize>
+    <maxHeapSize>512</maxHeapSize>
   </jre>
   <splash>
     <file>about.bmp</file>


### PR DESCRIPTION
We are seeing some sketches exceed the heap limits either through the JDT or ANTLR when they are very large (>50k lines). This PR increases the heap for helping the IDE keep up when the parse trees get larger. Separately, looking at benchmarks online, [Java 11 is fast but it may be a little less prudent on the heap](https://caff.de/posts/java-11-vs-8-performance/). Informally, I am seeing some of this myself. So, keeping with the past, increasing the default sketch max memory to match the new higher IDE limit.